### PR TITLE
Feat: adds route, controller and tests for item#show and item#patch

### DIFF
--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -4,4 +4,19 @@ class Api::V1::ItemsController < ApplicationController
     items = Item.all
     render json: ItemSerializer.new(items)
   end
+
+  def show
+    render json: ItemSerializer.new(Item.find(params[:id]))
+  end
+
+  def update
+    updated_item = Item.update(params[:id], item_params)
+    render json: ItemSerializer.new(updated_item)
+   end
+
+  private
+
+  def item_params
+    params.require(:item).permit(:name, :description, :unit_price, :merchant_id)
+  end
 end

--- a/app/controllers/api/v1/merchants_controller.rb
+++ b/app/controllers/api/v1/merchants_controller.rb
@@ -14,7 +14,7 @@ class Api::V1::MerchantsController < ApplicationController
 
     def show
         render json: MerchantSerializer.new(Merchant.find(params[:id]))
-     end
+    end
 
     def update
         merchant = Merchant.find(params[:id])

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,5 +12,9 @@ Rails.application.routes.draw do
   get "/api/v1/merchants/:id", to: "api/v1/merchants#show"
   patch "/api/v1/merchants/:id", to: "api/v1/merchants#update" 
   post "/api/v1/merchants", to: "api/v1/merchants#create"
+
+              
   get "/api/v1/items", to: "api/v1/items#index"
+  get "/api/v1/items/:id", to: "api/v1/items#show"
+  patch "/api/v1/items/:id", to: "api/v1/items#update" 
 end

--- a/spec/requests/api/v1/items_requests_spec.rb
+++ b/spec/requests/api/v1/items_requests_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.configure do |config| 
  config.formatter = :documentation 
- end
+end
 
  RSpec.describe "Items endpoints" do
   it "can send a list of items" do
@@ -42,7 +42,57 @@ RSpec.configure do |config|
 
       expect(attributes).to have_key(:merchant_id)
       expect(attributes[:merchant_id]).to be_a(Integer)
-
     end
   end
+   
+    describe "Fetch one item" do
+      it "can get one item by its id" do
+        Merchant.create!(id: 1, name: "Test Merchant")
+        id = Item.create!(name: "Mouse", description: "Clicks", unit_price:100.99 , merchant_id:1).id
+        get "/api/v1/items/#{id}"
+        item1 = JSON.parse(response.body, symbolize_names: true)[:data]
+      
+        expect(response).to be_successful  
+        expect(item1[:type]).to eq("item")
+        expect(item1).to have_key(:type)
+        expect(item1[:type]).to be_a(String)
+  
+        expect(item1).to have_key(:id)
+        expect(item1[:id]).to be_an(String)
+
+        attributes = item1[:attributes]
+        expect(item1).to have_key(:attributes)
+  
+        expect(attributes).to have_key(:name)
+        expect(attributes[:name]).to be_a(String)
+  
+        expect(attributes).to have_key(:description)
+        expect(attributes[:description]).to be_a(String)
+  
+        expect(attributes).to have_key(:unit_price)
+        expect(attributes[:unit_price]).to be_a(Float)
+         
+        expect(attributes).to have_key(:merchant_id)
+        expect(attributes[:merchant_id]).to be_a(Integer)
+      end
+    end
+
+    describe "Update New Item" do
+      it "can update an existing item" do
+        Merchant.create!(id: 1, name: "Test Merchant")
+        id = Item.create!(name: "Mouse", description: "Clicks", unit_price:100.99 , merchant_id:1).id
+        previous_name = Item.last.name
+        item_params = {name: "Tray"}
+        headers = {"CONTENT_TYPE" => "application/json"}
+      
+        patch "/api/v1/items/#{id}", headers: headers, params: JSON.generate({item: item_params})
+        updated_item = Item.find_by(id: id)
+  
+        expect(response).to be_successful
+        expect(updated_item.name).to_not eq(previous_name)
+        expect(updated_item.name).to eq("Tray")
+
+      end
+    end
+
 end

--- a/spec/requests/api/v1/merchants_requests_spec.rb
+++ b/spec/requests/api/v1/merchants_requests_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Merchants endpoints" do
     merchant2 = Merchant.create!(name: "Brown and Moms")
     merchant3 = Merchant.create!(name: "Brown and Dads")
 
-    get "/api/v1/items"
+    get "/api/v1/merchants"
     merchants = JSON.parse(response.body, symbolize_names: true)[:data]
     
     expect(response).to be_successful
@@ -29,7 +29,7 @@ RSpec.describe "Merchants endpoints" do
 
 
   describe "Fetch one merchant" do
-    it "can get one poster by its id" do
+    it "can return one merchant by its id" do
       id =  merchant1 = Merchant.create!(name: "Brown and Sons").id
       get "/api/v1/merchants/#{id}"
       merchant1 = JSON.parse(response.body, symbolize_names: true)[:data]


### PR DESCRIPTION
Update an Item
This PR implements the functionality for updating an item via the API. The PATCH /api/v1/items/:id endpoint now allows users to update an item’s details. If the item is found, the corresponding resource is updated with the provided information, and a JSON representation of the updated record is returned.

Fetch a Single Record
I’ve added the GET /api/v1/items/:id endpoint to retrieve a single item. If the item is found, the corresponding record is rendered as JSON.

Both features now have accompanying tests, routes, and controller actions.