### PR TITLE
Add flexibility to MerchantSerializer, fix duplicate index tests

### DIFF
--- a/app/controllers/api/v1/merchants_controller.rb
+++ b/app/controllers/api/v1/merchants_controller.rb
@@ -1,8 +1,8 @@
 class Api::V1::MerchantsController < ApplicationController
   def index
       merchants = Merchant.sort_and_filter(params)
-      render json: MerchantSerializer.new(merchants)
-    end
+      render json: MerchantSerializer.new(merchants, {params: {action: "index"} } )
+  end
 
   def show
       render json: MerchantSerializer.new(Merchant.find(params[:id]))

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -23,5 +23,9 @@ class Merchant < ApplicationRecord
     # That gives us access to ALL the merchants who have invoices actively associated with them
     # Then we .where for those merchants whose invoices have a status of "returned"
   end
+
+  def item_count 
+    self.items.count
+  end
 end
 

--- a/app/serializers/merchant_serializer.rb
+++ b/app/serializers/merchant_serializer.rb
@@ -1,10 +1,9 @@
 class MerchantSerializer
   include JSONAPI::Serializer
 
-  attributes :name, :created_at
+  attributes :name
 
-  # merchants passed in as arg in Serializer
-  attribute :item_count do |merchant|
-    merchant.items.count
-  end
+  attribute :item_count, if: Proc.new {|merchants, params| params && params[:action] == "index" }
+  # require "pry"; binding.pry
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,8 +12,8 @@ Rails.application.routes.draw do
   get "/api/v1/merchants/:id", to: "api/v1/merchants#show"
   patch "/api/v1/merchants/:id", to: "api/v1/merchants#update" 
   post "/api/v1/merchants", to: "api/v1/merchants#create"
-
   delete "/api/v1/merchants/:id", to: "api/v1/merchants#destroy"
+  
   get "/api/v1/items", to: "api/v1/items#index"
   get "/api/v1/items/:id", to: "api/v1/items#show"
   patch "/api/v1/items/:id", to: "api/v1/items#update" 

--- a/spec/requests/api/v1/merchants_requests_spec.rb
+++ b/spec/requests/api/v1/merchants_requests_spec.rb
@@ -39,16 +39,19 @@ RSpec.describe "Merchants endpoints", type: :request do
     end
   end
 
-  it "sorts merchants by creation date (newest first)" do
-    get "/api/v1/merchants?sorted=age"
-    merchants = JSON.parse(response.body, symbolize_names: true)[:data]
+  # describe "index sad paths" do
+  #   it "returns an empty array if DB empty" do
+  #     Merchant.delete_all
+
+  #     get "/api/v1/merchants"
+
+  #     merchants = JSON.parse(response.body, symbolize_names: true)[:data]
     
-    expect(response).to be_successful
+  #     expect(response).to be_successful
+  #     expect(merchants).to be_empty
 
-    creation_dates = merchants.map { |merchant| DateTime.parse(merchant[:attributes][:created_at]) }
-
-    expect(creation_dates).to eq(creation_dates.sort.reverse)
-  end
+  #   end
+  # end
 
   describe "Fetch one merchant" do
     it "can return one merchant by its id" do
@@ -147,9 +150,6 @@ RSpec.describe "Merchants endpoints", type: :request do
 
 
     it 'returns merchants sorted by creation date (newest first)' do
-      Merchant.create!(name: "Merchant A", created_at: 2.days.ago)
-      Merchant.create!(name: "Merchant B", created_at: 1.day.ago)
-      Merchant.create!(name: "Merchant C", created_at: Time.now)
 
       get "/api/v1/merchants?sorted=age"
 
@@ -157,37 +157,11 @@ RSpec.describe "Merchants endpoints", type: :request do
 
       expect(response).to be_successful
 
-      creation_dates = merchants.map { |merchant| DateTime.parse(merchant[:attributes][:created_at]) }
-
-      expect(creation_dates).to eq(creation_dates.sort.reverse)
+      expect(merchants[0][:attributes][:name]).to eq("Brown and Dads")
+      expect(merchants[1][:attributes][:name]).to eq("Brown and Moms")
+      expect(merchants[2][:attributes][:name]).to eq("Brown and Sons")
     end
 
-
-    # expect(creation_dates).to eq(creation_dates.sort.reverse) #this is not passing
-  
- 
-
-  # #   expect(merchants[:data][2][:attributes][:name]).to eq("Brown and Sons")
-  # #   expect(merchants[:data][1][:attributes][:name]).to eq("Brown and Moms")
-  # #   expect(merchants[:data][0][:attributes][:name]).to eq("Brown and Dads")
-  # # end
-  
-  
-  # # get all merchants with calculated count of items
-  # # THIS IS NOT CORRECT YET
-  # xit "can return the total merchant count" do
-    
-  #   get "/api/v1/merchants?sorted=age"
-  #   merchants = JSON.parse(response.body, symbolize_names: true)
-    
-  #   expect(response).to be_successful
-    
-  #   expect(merchants).to have_key(:meta)
-  #   expect(merchants[:meta][:count]).to eq(3)
-  #   expect(merchants[:data].count).to eq(3)
-  # end
-  
-  # get all merchants with returned items (check invoice)
   it "returns only merchants with returned items" do
     
     get "/api/v1/merchants?status=returned"
@@ -201,7 +175,3 @@ RSpec.describe "Merchants endpoints", type: :request do
 end
 
 
-
-
-
- 


### PR DESCRIPTION
This branch was originally intended for generating sad paths for merchant index, but we ran into a lot of bugs with our serializer and decided to pivot and deal with it immediately.  This is what has been updated/fixed:

- Removed duplicate sorting merchants by age test
- Made MerchantSerializer dynamic to add item_count to JSON only when index action is utilized
- Adds item_count as model method in order to call within conditionalized serializer