### PR TITLE
Added sad paths to handle and excetion for merchantitems and itemmerhants

### DIFF
--- a/app/controllers/api/v1/merchant_items_controller.rb
+++ b/app/controllers/api/v1/merchant_items_controller.rb
@@ -2,7 +2,7 @@ class Api::V1::MerchantItemsController < ApplicationController
   rescue_from ActiveRecord::RecordNotFound, with: :not_found_response
 
   def show
-    item = Item.find_by(id: params[:id])
+    item = Item.find(params[:id])
     if item
       merchant = item.merchant
       render json: MerchantSerializer.new(merchant)

--- a/spec/requests/api/v1/item_merchants_request_spec.rb
+++ b/spec/requests/api/v1/item_merchants_request_spec.rb
@@ -44,4 +44,27 @@ RSpec.describe "Item Merchants" do
       expect(item[:attributes][:merchant_id]).to eq(merchant.id)
     end
   end
+
+  it 'handles an exception gracefully with a error message' do 
+    get "/api/v1/merchants/9999/items"
+
+    expect(response).to have_http_status(404)
+    
+    json_response = JSON.parse(response.body, symbolize_names: true)
+    
+    expect(json_response).to have_key(:message)
+    expect(json_response[:message]).to be_a(String)
+
+    expect(json_response).to have_key(:errors)
+    expect(json_response[:errors]).to be_a(Array)
+
+    error = json_response[:errors].first
+
+    expect(error).to have_key(:status)
+    expect(error[:status]).to be_a(String)
+
+    expect(error).to have_key(:title)
+    expect(error[:title]).to be_a(String)
+    
+  end 
 end

--- a/spec/requests/api/v1/merchant_items_request_spec.rb
+++ b/spec/requests/api/v1/merchant_items_request_spec.rb
@@ -22,5 +22,29 @@ RSpec.describe "MerchantItems", type: :request do
       expect(merchant_response[:attributes][:name]).to be_a(String)
     end
   end
+
+  it 'handles an exception gracefully with a error message' do
+
+    get "/api/v1/items/9999/merchant"
+
+    expect(response).to have_http_status(404)
+    
+    json_response = JSON.parse(response.body, symbolize_names: true)
+    
+    expect(json_response).to have_key(:message)
+    expect(json_response[:message]).to be_a(String)
+
+    expect(json_response).to have_key(:errors)
+    expect(json_response[:errors]).to be_a(Array)
+
+    error = json_response[:errors].first
+
+    expect(error).to have_key(:status)
+    expect(error[:status]).to be_a(String)
+
+    expect(error).to have_key(:title)
+    expect(error[:title]).to be_a(String)
+    
+  end
 end
 


### PR DESCRIPTION
This code defines a test for the Api::V1::MerchantItemsController to ensure that it handles exceptions gracefully when a non-existent item is requested. It verifies that:

- HTTP Status: The response status code is 404 when the item is not found.
- Error Response Structure: The JSON response contains a message key with a string value and an errors key that is an array.
- Error Details: Each error object in the errors array contains status and title keys, both with string values.