### PR TITLE
Add 100% coverage for Merchant model

### DIFF
--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -42,7 +42,17 @@ RSpec.describe Merchant, type: :model do
 
       expect(result).to eq(expected)
     end
-  end
 
-    #need test for merchant find by name. 
+    context "filter_by_name" do
+      it "returns the 1st item in A-Z order with a case insensitive search" do
+        result = Merchant.filter_by_name("meRcHa")
+        expect(result.id).to eq(@merchant_1.id)
+      end
+      
+      it "returns nil" do
+        result = Merchant.filter_by_name("xxx")
+        expect(result).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR adds missing test coverage in the Merchant model for the filter_by_name class method.

It is almost identical to the previous PR in function addressing the Item model coverage.
![Screenshot 2024-09-16 at 5 25 46 PM](https://github.com/user-attachments/assets/ef42bdfa-721c-4302-8a03-69e42c0bb95c)
