### PR TITLE
Fix missing coverage in items_controller

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,18 +6,24 @@ class Item < ApplicationRecord
         order(:unit_price)
     end
 
+    # User can search by one of these things:
+        # name
+        # min_price
+        # max_price
+        # min_price & max_price
+
     def self.sort_and_filter(params)
         if params[:name] && (params[:min_price] || params[:max_price])
             raise ArgumentError.new("Cannot search by both name and price")
         end
 
-        if params[:min_price] && params[:min_price].to_f < 0
+        if params[:min_price].to_f < 0
             raise ArgumentError.new("min_price must be a positive number")
-        elsif params[:max_price] && params[:max_price].to_f < 0
+        elsif params[:max_price].to_f < 0
             raise ArgumentError.new("max_price must be a positive number")
         end
 
-        items = all
+        items = Item.all
         items = items.filter_by_name(params[:name]) if params[:name]
         items = items.filter_by_min(params[:min_price]) if params[:min_price]
         items = items.filter_by_max(params[:max_price]) if params[:max_price]

--- a/spec/requests/api/v1/items_requests_spec.rb
+++ b/spec/requests/api/v1/items_requests_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "Items endpoints" do
 
     end
   end
-   
+
     describe "Fetch one item" do
       it "can get one item by its id" do
         Merchant.create!(id: 1, name: "Test Merchant")
@@ -69,7 +69,7 @@ RSpec.describe "Items endpoints" do
   
         expect(attributes).to have_key(:unit_price)
         expect(attributes[:unit_price]).to be_a(Float)
-         
+
         expect(attributes).to have_key(:merchant_id)
         expect(attributes[:merchant_id]).to be_a(Integer)
       end
@@ -197,36 +197,149 @@ RSpec.describe "Items endpoints" do
       prices = items.map { |item| item[:attributes][:unit_price] }
     
       expect(prices).to eq(prices.sort)
-
     end
   end
 
+  it 'deletes the item and associated records, returns 204 no content' do
 
-    it 'deletes the item and associated records, returns 204 no content' do
-
-      merchant = Merchant.create!(name: "Test Merchant")
-      item = merchant.items.create!(name: "Test Item", description: "This is a test item", unit_price: 100.0)
-      invoice = Invoice.create!(merchant: merchant, customer: Customer.create!(first_name: "John", last_name: "Doe"), status: "shipped")
-      invoice_item = InvoiceItem.create!(item: item, invoice: invoice, quantity: 1, unit_price: item.unit_price)
+    merchant = Merchant.create!(name: "Test Merchant")
+    item = merchant.items.create!(name: "Test Item", description: "This is a test item", unit_price: 100.0)
+    invoice = Invoice.create!(merchant: merchant, customer: Customer.create!(first_name: "John", last_name: "Doe"), status: "shipped")
+    invoice_item = InvoiceItem.create!(item: item, invoice: invoice, quantity: 1, unit_price: item.unit_price)
 
 
-      expect(Item.count).to eq(1)
-      expect(InvoiceItem.count).to eq(1)
-      expect(Invoice.count).to eq(1)
+    expect(Item.count).to eq(1)
+    expect(InvoiceItem.count).to eq(1)
+    expect(Invoice.count).to eq(1)
 
-      delete "/api/v1/items/#{item.id}"
+    delete "/api/v1/items/#{item.id}"
 
-      expect(response).to have_http_status(:no_content)
-      expect(response.body).to be_empty
+    expect(response).to have_http_status(:no_content)
+    expect(response.body).to be_empty
 
-      expect(Item.count).to eq(0)
-      expect(InvoiceItem.count).to eq(0)
-      expect(Invoice.count).to eq(1) 
+    expect(Item.count).to eq(0)
+    expect(InvoiceItem.count).to eq(0)
+    expect(Invoice.count).to eq(1) 
 
-      expect { Item.find(item.id) }.to raise_error(ActiveRecord::RecordNotFound)
-      expect { InvoiceItem.find(invoice_item.id) }.to raise_error(ActiveRecord::RecordNotFound)
+    expect { Item.find(item.id) }.to raise_error(ActiveRecord::RecordNotFound)
+    expect { InvoiceItem.find(invoice_item.id) }.to raise_error(ActiveRecord::RecordNotFound)
+  end
+
+  describe "using the find_all controller action (un-RESTful route)" do
+    # •	What happens if I pass only the name filter?
+    # •	What if I pass only the min_price or only the max_price filter?
+    # •	What if I pass all filters together (e.g., name, min_price, and max_price)?
+    # •	What if none of the filters are passed?
+    before(:each) do
+      @merchant = Merchant.create!(id: 1, name: "Test Merchant")
+      @item_1 = Item.create!(name: "Thing", description: "Thingy", unit_price:10.99 , merchant_id: @merchant.id)
+      @item_2 = Item.create!(name: "Something", description: "Somethingy", unit_price:20.99 , merchant_id: @merchant.id)
+      @item_3 = Item.create!(name: "Anything", description: "Anythingy", unit_price:30.99 , merchant_id: @merchant.id)
+      @item_4 = Item.create!(name: "Nothing", description: "Nothingy", unit_price:40.99 , merchant_id: @merchant.id)
+    end
+    
+    it "can return items with a case insensitive search query by name" do
+
+      get "/api/v1/items/find_all?name=aNyTHIng"
+
+      items = JSON.parse(response.body, symbolize_names: true)[:data]
+
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+      expect(items.count).to eq(1)
+      
+      result = items.first
+      expect(result[:attributes][:name]).to eq(@item_3.name)
+      expect(result[:id].to_i).to eq(@item_3.id)
+    end
+
+    it "can return items with a partial case insensitive search query by name" do
+
+      get "/api/v1/items/find_all?name=tHiNG"
+      
+      items = JSON.parse(response.body, symbolize_names: true)[:data]
+      
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+      expect(items.count).to eq(4)
+      
+      result = items.map { |item| item[:id].to_i }
+      expect(result).to contain_exactly(@item_1.id, @item_2.id, @item_3.id, @item_4.id)
+    end
+
+    it "can return items with a min_price search query" do
+      
+      get "/api/v1/items/find_all?min_price=20"
+      
+      items = JSON.parse(response.body, symbolize_names: true)[:data]
+      
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+      expect(items.count).to eq(3)
+
+      result = items.map { |item| item[:id].to_i }
+      expect(result).to contain_exactly(@item_2.id, @item_3.id, @item_4.id)
+    end
+
+    it "can return items with a max_price search query" do
+      
+      get "/api/v1/items/find_all?max_price=30"
+      
+      items = JSON.parse(response.body, symbolize_names: true)[:data]
+      
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+      expect(items.count).to eq(2)
+
+      result = items.map { |item| item[:id].to_i }
+      expect(result).to contain_exactly(@item_1.id, @item_2.id)
+    end
+
+    it "can return items within a price range using both min_price AND max_price search queries" do
+      
+      get "/api/v1/items/find_all?min_price=10&max_price=40"
+      
+      items = JSON.parse(response.body, symbolize_names: true)[:data]
+      
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
+      expect(items.count).to eq(3)
+
+      result = items.map { |item| item[:id].to_i }
+      expect(result).to contain_exactly(@item_1.id, @item_2.id, @item_3.id)
+    end
+
+    it "CANNOT return items when a query includes both a name and a min_price query simultaneously" do
+      
+      get "/api/v1/items/find_all?name=tHiNG&min_price=10"
+      
+      items = JSON.parse(response.body, symbolize_names: true)[:data]
+      
+      expect(response).to_not be_successful
+      expect(response.status).to_not eq(404)  # Not really sure how to do this yet.
+    end
+
+    it "CANNOT return items when a query includes both a name and a max_price query simultaneously" do
+      
+      get "/api/v1/items/find_all?name=tHiNG&max_price=40"
+      
+      items = JSON.parse(response.body, symbolize_names: true)[:data]
+      
+      expect(response).to_not be_successful
+      expect(response.status).to_not eq(404)  # Not really sure how to do this yet.
+    end
+
+    it "does NOT return a 404 status code if no items are returned" do
+      
+      get "/api/v1/items/find_all?name=XXXXX"
+      
+      items = JSON.parse(response.body, symbolize_names: true)[:data]
+      
+      expect(response).to be_successful
+      expect(response.status).to_not eq(404)  # Not really sure how to do this yet.
     end
   end
+end
 
 
 

--- a/spec/requests/api/v1/merchants_requests_spec.rb
+++ b/spec/requests/api/v1/merchants_requests_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe "Merchants endpoints", type: :request do
     end
   end
 
- 
+
   describe 'sad paths fetch one merchant' do
     it "will gracefully handle if a merchant id doesn't exist" do
       get "/api/v1/merchants/9999" 


### PR DESCRIPTION
This PR addressed the gaps in coverage regarding the un-RESTful route in the items_controller.  Many tests were required in order to fully cover every possible combination of search queries passed into this un-RESTful route.

I also removed redundant code in the item.rb file.
- All RSpec tests are still passing.

I'm just realizing we can remove some comments, but that can happen as a final refactor.

![Screenshot 2024-09-16 at 8 56 42 PM](https://github.com/user-attachments/assets/cb931626-9aff-4e7f-8d74-cec220846491)
